### PR TITLE
Bug: `options` argument is ignored

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 //
 'use strict';
 
-module.exports = function umlPlugin(md, name, options) {
+module.exports = function umlPlugin(md, options) {
 
   function generateSourceDefault(umlCode) {
     var deflate = require('./lib/deflate.js');


### PR DESCRIPTION
Environment
-------------

- markdown-it:8.4.0
- markdown-it-plantuml:0.3.1

Summary
----------

According to `README.md`, the usage is

```javascript
var md = require('markdown-it')()
            .use(require('markdown-it-plantuml')[, options]);
```

But the current code is following

```
function umlPlugin(md, name, options) {
```

Therefore, `options` object that specified as the second argument is ignored.
Additionally, `name` variable is unused.