### PR TITLE
feat: encoding the text diagram description in UTF-8

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function umlPlugin(md, options) {
   function generateSourceDefault(umlCode) {
     var deflate = require('./lib/deflate.js');
     var zippedCode =
-      deflate.encode64(deflate.zip_deflate('@startuml\n' + umlCode + '\n@enduml', 9));
+      deflate.encode64(deflate.zip_deflate(unescape(encodeURIComponent('@startuml\n' + umlCode + '\n@enduml')), 9));
     return 'http://www.plantuml.com/plantuml/svg/' + zippedCode;
   }
 


### PR DESCRIPTION
Thanks for this package, but when I use some Chinese character in the text diagram description, the uml sever response an error.
I find this issue just due to character encoding, so I try to fix it.