### PR TITLE
Support alt text for fenced plantuml blocks

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,28 @@ module.exports = function umlPlugin(md, options) {
       render = options.render || md.renderer.rules.image,
       generateSource = options.generateSource || generateSourceDefault;
 
+  function pushDiagramToken(state, contents, info, markup, map, altText) {
+    var altToken = [];
+    var alt = (altText && altText.length) ? altText : 'uml diagram';
+
+    state.md.inline.parse(
+      alt,
+      state.md,
+      state.env,
+      altToken
+    );
+
+    var token = state.push('uml_diagram', 'img', 0);
+    token.attrs = [ [ 'src', generateSource(contents, options) ], [ 'alt', '' ] ];
+    token.block = true;
+    token.children = altToken;
+    token.info = info;
+    token.map = map;
+    token.markup = markup;
+
+    return token;
+  }
+
   function uml(state, startLine, endLine, silent) {
     var nextLine, markup, params, token, i,
         autoClosed = false,
@@ -112,32 +134,160 @@ module.exports = function umlPlugin(md, options) {
       .slice(startLine + 1, nextLine)
       .join('\n');
 
-    // We generate a token list for the alt property, to mimic what the image parser does.
-    var altToken = [];
     // Remove leading space if any.
-    var alt = params ? params.slice(1) : 'uml diagram';
-    state.md.inline.parse(
-      alt,
-      state.md,
-      state.env,
-      altToken
+    var altText = params ? params.slice(1) : '';
+    token = pushDiagramToken(
+      state,
+      contents,
+      params,
+      markup,
+      [ startLine, nextLine ],
+      altText
     );
-
-    token = state.push('uml_diagram', 'img', 0);
-    // alt is constructed from children. No point in populating it here.
-    token.attrs = [ [ 'src', generateSource(contents, options) ], [ 'alt', '' ] ];
-    token.block = true;
-    token.children = altToken;
-    token.info = params;
-    token.map = [ startLine, nextLine ];
-    token.markup = markup;
 
     state.line = nextLine + (autoClosed ? 1 : 0);
 
     return true;
   }
 
+  /**
+   * detectFence quickly verifies that the current line starts a PlantUML fence.
+   * Example for 
+   * 
+   * ```plantuml diagram caption
+   * @startuml
+   * Alice -> Bob: Authentication Request
+   * Bob --> Alice: Authentication Response
+   * @enduml
+   * ```
+   * 
+   * Returns:
+   *   marker        => 0x60 (the backtick code fence delimiter)
+   *   markup        => "```" (the raw fence marker string)
+   *   paramsTrim    => "plantuml diagram caption" (info string after markup)
+   *   markerLength  => 3 (count of repeated marker characters)
+   */
+  function detectFence(state, startLine) {
+    var mem,
+        pos = state.bMarks[startLine] + state.tShift[startLine],
+        max = state.eMarks[startLine];
+
+    if (pos + 3 > max) { return null; }
+
+    var marker = state.src.charCodeAt(pos);
+
+    if (marker !== 0x7E/* ~ */ && marker !== 0x60 /* ` */) {
+      return null;
+    }
+
+    mem = pos;
+    pos = state.skipChars(pos, marker);
+
+    var len = pos - mem;
+
+    if (len < 3) { return null; }
+
+    var markup = state.src.slice(mem, pos);
+    var paramsTrim = state.src.slice(pos, max).trim();
+
+    if (paramsTrim.split(/\s+/g)[0] !== 'plantuml') {
+      return null;
+    }
+
+    return {
+      marker: marker,
+      markup: markup,
+      paramsTrim: paramsTrim,
+      markerLength: len
+    };
+  }
+
+  function extractFenceContents(state, startLine, endLine, detection) {
+    var nextLine = startLine;
+    var pos;
+    var mem;
+    var max;
+
+    for (;;) {
+      nextLine++;
+      if (nextLine >= endLine) {
+        break;
+      }
+
+      pos = mem = state.bMarks[nextLine] + state.tShift[nextLine];
+      max = state.eMarks[nextLine];
+
+      if (pos < max && state.sCount[nextLine] < state.blkIndent) {
+        break;
+      }
+
+      if (state.src.charCodeAt(pos) !== detection.marker) { continue; }
+
+      if (state.sCount[nextLine] - state.blkIndent >= 4) {
+        continue;
+      }
+
+      pos = state.skipChars(pos, detection.marker);
+
+      if (pos - mem < detection.markerLength) { continue; }
+
+      pos = state.skipSpaces(pos);
+
+      if (pos < max) { continue; }
+
+      break;
+    }
+
+    var indent = state.sCount[startLine];
+
+    var endReached = nextLine >= endLine;
+    state.line = nextLine + (endReached ? 0 : 1);
+
+    var contents = state.src
+      .split('\n')
+      .slice(startLine + 1, nextLine)
+      .map(function (line, idx) {
+        var sCountIdx = startLine + 1 + idx;
+        var shift = (sCountIdx < state.sCount.length) ? state.sCount[sCountIdx] : 0;
+        if (shift > indent) { shift = indent; }
+        return line.slice(shift);
+      })
+      .join('\n');
+
+    return contents;
+  }
+
+  function replaceFenceWithDiagram(state, startLine, contents, detection) {
+    var altText = detection.paramsTrim.slice('plantuml'.length).trim();
+
+    pushDiagramToken(
+      state,
+      contents,
+      detection.paramsTrim,
+      detection.markup,
+      [ startLine, state.line ],
+      altText
+    );
+  }
+
+  function fence(state, startLine, endLine, silent) {
+    var detection = detectFence(state, startLine);
+
+    if (!detection) { return false; }
+
+    if (silent) { return true; }
+
+    var contents = extractFenceContents(state, startLine, endLine, detection);
+
+    replaceFenceWithDiagram(state, startLine, contents, detection);
+
+    return true;
+  }
+
   md.block.ruler.before('fence', 'uml_diagram', uml, {
+    alt: [ 'paragraph', 'reference', 'blockquote', 'list' ]
+  });
+  md.block.ruler.before('fence', 'uml_diagram_fence', fence, {
     alt: [ 'paragraph', 'reference', 'blockquote', 'list' ]
   });
   md.renderer.rules.uml_diagram = render;

--- a/test/fixtures/fence.txt
+++ b/test/fixtures/fence.txt
@@ -1,0 +1,91 @@
+Fenced plantuml block with @startuml/@enduml
+.
+```plantuml
+@startuml
+Bob -> Alice : hello
+@enduml
+```
+.
+<img src="https://www.plantuml.com/plantuml/svg/SoWkIImgAStDuNA0ivpoanHqxHGSSpAJKnMi539IStBokHnIyrB0oY0q0000" alt="uml diagram">
+.
+
+
+Fenced plantuml block without @startuml/@enduml
+.
+```plantuml
+Bob -> Alice : hello
+```
+.
+<img src="https://www.plantuml.com/plantuml/svg/SoWkIImgAStDuNBAJrBGjLDmpCbCJbMmKiX8pSd9vt98pKi1IW80" alt="uml diagram">
+.
+
+
+Fenced plantuml block with alt text
+.
+```plantuml diagram caption
+Bob -> Alice : hello
+```
+.
+<img src="https://www.plantuml.com/plantuml/svg/SoWkIImgAStDuNBAJrBGjLDmpCbCJbMmKiX8pSd9vt98pKi1IW80" alt="diagram caption">
+.
+
+
+Fenced plantuml block where the fence caption wins
+.
+```plantuml fence caption
+@startuml inner caption
+Bob -> Alice : hello
+@enduml
+```
+.
+<img src="https://www.plantuml.com/plantuml/svg/SoWkIImgAStDuNA0iHGoy_9IYnII4mjAClFpk9poanHqxHGSSpAJKnMi539IStBokHnIyrB0cY0q0000" alt="fence caption">
+.
+
+
+Fenced plantuml block with indentation
+.
+   ```plantuml
+   Bob -> Alice : hello
+   ```
+.
+<img src="https://www.plantuml.com/plantuml/svg/SoWkIImgAStDuNBAJrBGjLDmpCbCJbMmKiX8pSd9vt98pKi1IW80" alt="uml diagram">
+.
+
+
+Fenced block with other language should not be processed
+.
+```javascript
+Bob -> Alice : hello
+```
+.
+<pre><code class="language-javascript">Bob -&gt; Alice : hello
+</code></pre>
+.
+
+
+Fenced plantuml with tildes
+.
+~~~plantuml
+Bob -> Alice : hello
+~~~
+.
+<img src="https://www.plantuml.com/plantuml/svg/SoWkIImgAStDuNBAJrBGjLDmpCbCJbMmKiX8pSd9vt98pKi1IW80" alt="uml diagram">
+.
+
+
+Multiple fenced plantuml blocks
+.
+```plantuml
+A -> B : first
+```
+
+Some text in between
+
+```plantuml
+C -> D : second
+```
+.
+<img src="https://www.plantuml.com/plantuml/svg/SoWkIImgAStDuN9KqBLJS5AmKaZBB2ekuN98pKi12WC0" alt="uml diagram">
+<p>Some text in between</p>
+<img src="https://www.plantuml.com/plantuml/svg/SoWkIImgAStDuN9MqBLJS56mKYXEJSxFI-5oICrB0Oe30000" alt="uml diagram">
+.

--- a/test/index.js
+++ b/test/index.js
@@ -46,4 +46,10 @@ describe('markdown-it-plantuml', function () {
     { header: true },
     parserWithCustomServer
   );
+
+  generate(
+    path.join(__dirname, 'fixtures/fence.txt'),
+    { header: true },
+    defaultParser
+  );
 });


### PR DESCRIPTION
Currently the plugin only detects `@startuml…@enduml` markers outside fenced sections. This commit adds support for fenced PlantUML diagrams, for example:

````markdown
```plantuml [optional caption]
Alice -> Bob : ping
```

```plantuml [optional caption]
@startuml
Alice -> Bob : ping
@enduml
```
````

Rationale: common tooling (e.g. VS Code and IntelliJ plugins) encourages the fenced syntax, so aligning with it avoids surprises and improves interop.